### PR TITLE
5 fix optimize recomposition

### DIFF
--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -70,6 +70,17 @@
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="caiman" />
+          <option name="id" value="caiman" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="960" />
+          <option name="screenY" value="2142" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="29" />
           <option name="brand" value="samsung" />
           <option name="codename" value="crownqlteue" />
@@ -145,6 +156,17 @@
           <option name="screenDensity" value="280" />
           <option name="screenX" value="720" />
           <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="komodo" />
+          <option name="id" value="komodo" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro XL" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="1008" />
+          <option name="screenY" value="2244" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -234,6 +256,17 @@
           <option name="screenDensity" value="320" />
           <option name="screenX" value="1600" />
           <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tokay" />
+          <option name="id" value="tokay" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="29" />

--- a/app/src/main/java/tree/ralph/mindmapmemo/ErrorResult.kt
+++ b/app/src/main/java/tree/ralph/mindmapmemo/ErrorResult.kt
@@ -1,0 +1,13 @@
+package tree.ralph.mindmapmemo
+
+/**
+ *
+ * 2024-08-23 18:55:21.326 31738-31738 DEBUG                   pid-31738                            A  Cmdline: tree.ralph.mindmapmemo
+ * 2024-08-23 18:55:21.326 31738-31738 DEBUG                   pid-31738                            A  pid: 26824, tid: 27570, name: DefaultDispatch  >>> tree.ralph.mindmapmemo <<<
+ * 2024-08-23 18:55:21.326 31738-31738 DEBUG                   pid-31738                            A        #02 pc 00000000022a8458  /memfd:jit-cache (deleted) (offset 0x2000000) (tree.ralph.mindmapmemo.presentation.mindmap.MindMapViewModel.access$operate+88)
+ * 2024-08-23 18:55:21.326 31738-31738 DEBUG                   pid-31738                            A        #03 pc 00000000020cc14c  /memfd:jit-cache (deleted) (offset 0x2000000) (tree.ralph.mindmapmemo.presentation.mindmap.MindMapViewModel$draw$1.invokeSuspend+444)
+ * 2024-08-23 18:55:21.327 31738-31738 DEBUG                   pid-31738                            A        #13 pc 00000000001e34f4  /data/app/~~GF8Si4_QgGo4MvJ-4waNdw==/tree.ralph.mindmapmemo-oy5o8Q9Zzbls8W9CzZagSw==/base.apk (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker+0)
+ * 2024-08-23 18:55:21.327 31738-31738 DEBUG                   pid-31738                            A        #18 pc 00000000001e34dc  /data/app/~~GF8Si4_QgGo4MvJ-4waNdw==/tree.ralph.mindmapmemo-oy5o8Q9Zzbls8W9CzZagSw==/base.apk (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run+0)
+ *
+ *
+ * */

--- a/app/src/main/java/tree/ralph/mindmapmemo/presentation/mindmap/Constant.kt
+++ b/app/src/main/java/tree/ralph/mindmapmemo/presentation/mindmap/Constant.kt
@@ -1,7 +1,12 @@
 package tree.ralph.mindmapmemo.presentation.mindmap
 
+import android.content.res.Resources
+
 const val STROKE_WIDTH = 2f
 const val STROKE_ALPHA = 0.7f
 const val STROKE_BOX_SIZE_THRESHOLD = 6.0
 
 const val COLLISION_THRESHOLD = 45
+
+val screenWidth = Resources.getSystem().displayMetrics.widthPixels
+val screenHeight = Resources.getSystem().displayMetrics.heightPixels

--- a/app/src/main/java/tree/ralph/mindmapmemo/presentation/mindmap/Util.kt
+++ b/app/src/main/java/tree/ralph/mindmapmemo/presentation/mindmap/Util.kt
@@ -4,9 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import org.jsoup.Jsoup
-import tree.ralph.mindmapmemo.data.remote.model.OpenProtocolResponse
-import java.util.regex.Pattern
 import kotlin.math.abs
 
 @Composable


### PR DESCRIPTION
close #5 

![composition_optimize_test_video](https://github.com/user-attachments/assets/20b86111-0044-42d7-b267-3a94f47cb2a0)

- MindMap 구성을 위해 사용하던 Node, Edge의 타입을 List<State>에서 SnapshotStateList로 변경
- 추상화하여 사용하던 NodeComposable, EdgeComposable을 코드를 직접 작성해 주니 불필요한 Recomposition 생략 되는 것 확인. 이후 원인이 파악되면 다시 함수로 작성하여 적용할 예정
- 코드 수정을 통해 op를 통한 offset 변경에 의한 Recomposition 생략